### PR TITLE
chore: add github workflow for authenticating to google cloud

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: 'Authenticate to Google Cloud and Setup Cloud SDK'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  job:
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: actions/checkout@v3
+    
+    - id: auth
+      name: Authenticate to Google Cloud
+      # You may pin to the exact commit or the version.
+      # uses: google-github-actions/auth@81012c2689e66f7f020ed6d8ab43596a0f8b503a
+      uses: google-github-actions/auth@v0.7.3
+      with:
+        create_credentials_file: true
+        # The full identifier of the Workload Identity Provider, including the
+        # project number, pool name, and provider name. If provided, this must be
+        # the full identifier which includes all parts, for example: 
+        # "projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider".
+        # This is mutually exclusive with "credentials_json".
+        workload_identity_provider: "${{ secrets.GCP_IDENTITY_POOL_PROVIDER_ID }}" # optional
+        # Email address or unique identifier of the Google Cloud service account for
+        # which to generate credentials. This is required if
+        # "workload_identity_provider" is specified.
+        service_account: "${{ secrets.GCP_SERVICE_ACCOUNT }}" # optional
+        token_format: access_token # optional
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Google Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'


### PR DESCRIPTION
Address [TWREPORTER-396](https://twreporter-org.atlassian.net/browse/TWREPORTER-396).

This change adds workflow for authenticating to Google Cloud
with GitHub Actions OIDC tokens and Workload Identity Federation.